### PR TITLE
MapperのSQL文の書き方を修正

### DIFF
--- a/src/main/java/com/example/api/repository/DateCalcMapper.java
+++ b/src/main/java/com/example/api/repository/DateCalcMapper.java
@@ -13,24 +13,24 @@ import com.example.api.entity.DateCalc;
 @Mapper
 public interface DateCalcMapper {
 
-	// select全件
-	@Select("select * from datecalc")
+	// SELECT全件
+	@Select("SELECT * FROM datecalc")
 	public List<DateCalc> selectAll();
 
-	// select１件
-	@Select("SELECT * FROM datecalc where id = #{id}")
+	// SELECT１件
+	@Select("SELECT * FROM datecalc WHERE id = #{id}")
 	public DateCalc selectOne(int id);
 
 	// 新規登録
-	@Insert("insert into datecalc  (name, plusyear, plusmonth, plusday) values (#{name}, #{plusyear}, #{plusmonth}, #{plusday})")
+	@Insert("INSERT INTO datecalc  (name, plusyear, plusmonth, plusday) VALUES (#{name}, #{plusyear}, #{plusmonth}, #{plusday})")
 	public void insertOne(DateCalc dateCalc);
 
 	// 更新
-	@Update("update datecalc set name = #{name}, plusyear = #{plusyear}, plusmonth = #{plusmonth}, plusday = #{plusday} where id = #{id}")
+	@Update("UPDATE datecalc SET name = #{name}, plusyear = #{plusyear}, plusmonth = #{plusmonth}, plusday = #{plusday} WHERE id = #{id}")
 	public void updateOne(DateCalc dateCalc);
 
 	// 削除
-	@Delete("delete from datecalc where id = #{id}")
+	@Delete("DELETE FROM datecalc WHERE id = #{id}")
 	public void deleteOne(DateCalc dateCalc);
 
 }


### PR DESCRIPTION
## 変更概要
MapperのSQL文の書き方を変更
- SELECT、UPDATE、FROMなどSQLの文法上の用語は大文字
- テーブル名、カラム名は小文字のスネークケース

## やったこと
* [x] SQLの文法上の用語を大文字に変更
